### PR TITLE
[BUG] - Error al publicar el paquete npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build ngx-dynamic-form",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "semantic-release": "semantic-release --branches master"
+    "semantic-release": "semantic-release"
   },
   "private": false,
   "dependencies": {


### PR DESCRIPTION
## Descripción

Se cambia el comando del `semantic-release` para que analice todas las ramas, no solo `master`.