### PR TITLE
[BUG] - Error de pago requerido al publicar el paquete npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jvlsoft-dev/ngx-dynamic-form.git"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Descripción

Al intentar publicar el paquete *npm* el `semantic-release` lanza un error **402 PAYMENT REQUIRED**, para solucionarlo se modifica `publishConfig` a `public`.