### PR TITLE
[BUG] - Agregar parámetros al comando de semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "ng build ngx-dynamic-form",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release --branches master"
   },
   "private": false,
   "dependencies": {


### PR DESCRIPTION
## Descripción

Se agrega el parámetro `--branches master` al comando `semantic-release`.