### PR TITLE
[BUG] - Arreglar errores al implementar la librería en otros proyectos

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-dynamic-form',
-  template: `<ngx-dynamic-form [config]="formConfig"></ngx-dynamic-form>`,
+  template: `<ngx-dynamic-form [config]="formConfig" [onlyFields]="false" title="User" [hasPrefix]="false"
+        [saveButton]="false" [canGoBack]="false"></ngx-dynamic-form>`,
 })
 export class DynamicFormComponent {
   formConfig = [
@@ -104,6 +105,9 @@ export class DynamicFormComponent {
   ];
 }
 ```
+For:
+![image](https://github.com/user-attachments/assets/f570023c-9bed-4df4-ae1e-8c52edd38b3d)
+
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ngx-dynamic-form
 
-The `ngx-dynamic-form` is a library that works in Angular 16 with Bootstrap 5 and FontAwesome to generate forms in a simple and dynamic way.
+The `ngx-dynamic-form` is a library that works in Angular 16 with Bootstrap 5 to generate forms in a simple and dynamic way.
 
 ## Table of Contents
 
@@ -23,7 +23,7 @@ Then add the following styles:
 
 ```scss
 @import "~bootstrap/dist/css/bootstrap.min.css";
-@import "~@fortawesome/fontawesome-free/css/all.css";
+@import '~bootstrap-icons/font/bootstrap-icons.css';
 @import "~@ng-select/ng-select/themes/default.theme.css";
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ The `ngx-dynamic-form` is a library that works in Angular 16 with Bootstrap 5 an
 To install the library, run:
 
 ```bash
-yarn add ngx-dynamic-form
+yarn add @jvlsoft/ngx-dynamic-form
 ```
 
 Then add the following styles:
 
 ```scss
-@import "~node_modules/bootstrap/dist/css/bootstrap.min.css";
-@import "~node_modules/@fortawesome/fontawesome-free/css/all.css";
-@import "~node_modules/@ng-select/ng-select/themes/default.theme.css";
+@import "~bootstrap/dist/css/bootstrap.min.css";
+@import "~@fortawesome/fontawesome-free/css/all.css";
+@import "~@ng-select/ng-select/themes/default.theme.css";
 ```
+
+Note: **Make sure your project has routing, otherwise the library won't work**
 
 ## Building the Project
 
@@ -58,7 +60,7 @@ Then navigate to `http://localhost:4200/` in your browser.
 Here's a basic example of how to use the library in your Angular project:
 
 ```typescript
-import { DynamicFormComponent, FormInputComponent } from 'ngx-dynamic-form';
+import { DynamicFormComponent, FormInputComponent } from '@jvlsoft/ngx-dynamic-form';
 
 @NgModule({
   imports: [

--- a/angular.json
+++ b/angular.json
@@ -63,10 +63,7 @@
               "projects/demo-app/src/assets"
             ],
             "styles": [
-              "projects/demo-app/src/styles.scss",
-              "node_modules/bootstrap/dist/css/bootstrap.min.css",
-              "node_modules/@fortawesome/fontawesome-free/css/all.css",
-              "node_modules/@ng-select/ng-select/themes/default.theme.css"
+              "projects/demo-app/src/styles.scss"
             ],
             "scripts": []
           },
@@ -129,10 +126,7 @@
               "projects/demo-app/src/assets"
             ],
             "styles": [
-              "projects/demo-app/src/styles.scss",
-              "node_modules/bootstrap/dist/css/bootstrap.min.css",
-              "node_modules/@fortawesome/fontawesome-free/css/all.css",
-              "node_modules/@ng-select/ng-select/themes/default.theme.css"
+              "projects/demo-app/src/styles.scss"
             ],
             "scripts": []
           }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
-    "@fortawesome/fontawesome-free": "^6.6.0",
     "@ng-select/ng-select": "11.x",
     "@types/lodash": "^4.17.7",
     "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.11.3",
     "lodash": "^4.17.21",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
@@ -40,8 +40,8 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
     "ng-packagr": "^16.2.0",
-    "typescript": "~5.1.3",
-    "semantic-release": "^24.1.2"
+    "semantic-release": "^24.1.2",
+    "typescript": "~5.1.3"
   },
   "repository": {
     "type": "git",

--- a/projects/demo-app/src/app/components/dynamic-form-examples/dynamic-form-examples.component.html
+++ b/projects/demo-app/src/app/components/dynamic-form-examples/dynamic-form-examples.component.html
@@ -19,8 +19,8 @@
     <h3 class="my-3">Generic Add Examples</h3>
     <div class="d-flex justify-content-center flex-column align-items-center">
         <div>
-            <button class="m-3 btn btn-primary" (click)="goTo('person')"><i class="fa fa-plus"></i> Create Example</button>
-            <button class="m-3 btn btn-primary" (click)="goTo('person/' + (person.value || 1))"><i class="fa fa-edit"></i> Edit Example</button>
+            <button class="m-3 btn btn-primary" (click)="goTo('person')"><i class="bi bi-plus"></i> Create Example</button>
+            <button class="m-3 btn btn-primary" (click)="goTo('person/' + (person.value || 1))"><i class="bi bi-pencil-square"></i> Edit Example</button>
         </div>
         <select class="form-select" #person multiple aria-label="multiple select example" [ngStyle]="{'max-width': '400px'}">
             <option *ngFor="let item of getPersons()" [value]="item.id" class="mx-3">{{ item.name }}, age {{item.age}}{{item.color ?

--- a/projects/demo-app/src/styles.scss
+++ b/projects/demo-app/src/styles.scss
@@ -1,5 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
 
-@import "~node_modules/bootstrap/dist/css/bootstrap.min.css";
-@import "~node_modules/@fortawesome/fontawesome-free/css/all.css";
-@import "~node_modules/@ng-select/ng-select/themes/default.theme.css";
+@import "~bootstrap/dist/css/bootstrap.min.css";
+@import '~bootstrap-icons/font/bootstrap-icons.css';
+@import "~@ng-select/ng-select/themes/default.theme.css";

--- a/projects/ngx-dynamic-form/README.md
+++ b/projects/ngx-dynamic-form/README.md
@@ -1,6 +1,6 @@
 # ngx-dynamic-form
 
-The `ngx-dynamic-form` is a library that works in Angular 16 with Bootstrap 5 and FontAwesome to generate forms in a simple and dynamic way.
+The `ngx-dynamic-form` is a library that works in Angular 16 with Bootstrap 5 to generate forms in a simple and dynamic way.
 
 ## Installation
 
@@ -14,7 +14,7 @@ Then add the following styles:
 
 ```scss
 @import "~bootstrap/dist/css/bootstrap.min.css";
-@import "~@fortawesome/fontawesome-free/css/all.css";
+@import '~bootstrap-icons/font/bootstrap-icons.css';
 @import "~@ng-select/ng-select/themes/default.theme.css";
 ```
 

--- a/projects/ngx-dynamic-form/README.md
+++ b/projects/ngx-dynamic-form/README.md
@@ -43,7 +43,8 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-dynamic-form',
-  template: `<ngx-dynamic-form [config]="formConfig"></ngx-dynamic-form>`,
+  template: `<ngx-dynamic-form [config]="inputsConfig" [onlyFields]="false" title="User" [hasPrefix]="false"
+        [saveButton]="false" [canGoBack]="false"></ngx-dynamic-form>`,
 })
 export class DynamicFormComponent {
   formConfig = [
@@ -69,6 +70,9 @@ export class DynamicFormComponent {
   ];
 }
 ```
+
+![image](https://github.com/user-attachments/assets/f570023c-9bed-4df4-ae1e-8c52edd38b3d)
+
 
 ## API
 

--- a/projects/ngx-dynamic-form/README.md
+++ b/projects/ngx-dynamic-form/README.md
@@ -7,23 +7,25 @@ The `ngx-dynamic-form` is a library that works in Angular 16 with Bootstrap 5 an
 To install the library, run:
 
 ```bash
-npm install ngx-dynamic-form
+yarn add @jvlsoft/ngx-dynamic-form
 ```
 
 Then add the following styles:
 
 ```scss
-@import "~node_modules/bootstrap/dist/css/bootstrap.min.css";
-@import "~node_modules/@fortawesome/fontawesome-free/css/all.css";
-@import "~node_modules/@ng-select/ng-select/themes/default.theme.css";
+@import "~bootstrap/dist/css/bootstrap.min.css";
+@import "~@fortawesome/fontawesome-free/css/all.css";
+@import "~@ng-select/ng-select/themes/default.theme.css";
 ```
+
+Note: **Make sure your project has routing, otherwise the library won't work**
 
 ## Usage
 
 Here's a basic example of how to use the library in your Angular project:
 
 ```typescript
-import { DynamicFormComponent, FormInputComponent } from 'ngx-dynamic-form';
+import { DynamicFormComponent, FormInputComponent } from '@jvlsoft/ngx-dynamic-form';
 
 @NgModule({
   imports: [

--- a/projects/ngx-dynamic-form/ng-package.json
+++ b/projects/ngx-dynamic-form/ng-package.json
@@ -3,5 +3,12 @@
   "dest": "../../dist/ngx-dynamic-form",
   "lib": {
     "entryFile": "src/public-api.ts"
-  }
+  },
+  "allowedNonPeerDependencies": [
+    "@fortawesome/fontawesome-free",
+    "@ng-select/ng-select",
+    "@types/lodash",
+    "bootstrap",
+    "lodash"
+  ]
 }

--- a/projects/ngx-dynamic-form/ng-package.json
+++ b/projects/ngx-dynamic-form/ng-package.json
@@ -5,7 +5,7 @@
     "entryFile": "src/public-api.ts"
   },
   "allowedNonPeerDependencies": [
-    "@fortawesome/fontawesome-free",
+    "bootstrap-icons",
     "@ng-select/ng-select",
     "@types/lodash",
     "bootstrap",

--- a/projects/ngx-dynamic-form/package.json
+++ b/projects/ngx-dynamic-form/package.json
@@ -3,15 +3,15 @@
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^16.2.0",
-    "@angular/core": "^16.2.0",
+    "@angular/core": "^16.2.0"
+  },
+  "dependencies": {
+    "tslib": "^2.3.0",
     "@fortawesome/fontawesome-free": "^6.6.0",
     "@ng-select/ng-select": "11.x",
     "@types/lodash": "^4.17.7",
     "bootstrap": "^5.3.3",
     "lodash": "^4.17.21"
-  },
-  "dependencies": {
-    "tslib": "^2.3.0"
   },
   "sideEffects": false
 }

--- a/projects/ngx-dynamic-form/package.json
+++ b/projects/ngx-dynamic-form/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "@fortawesome/fontawesome-free": "^6.6.0",
+    "bootstrap-icons": "^1.11.3",
     "@ng-select/ng-select": "11.x",
     "@types/lodash": "^4.17.7",
     "bootstrap": "^5.3.3",

--- a/projects/ngx-dynamic-form/src/lib/components/form-header/form-header.component.html
+++ b/projects/ngx-dynamic-form/src/lib/components/form-header/form-header.component.html
@@ -6,7 +6,7 @@
     <!-- Go back button -->
     <div *ngIf="canGoBack" class="card-toolbar">
         <button (click)="goBack()" class="btn btn-light" type="button">
-            <i class="fa fa-arrow-left me-2"></i>Atrás
+            <i class="bi bi-arrow-left me-2"></i>Atrás
         </button>
     </div>
 </div>

--- a/projects/ngx-dynamic-form/src/lib/fields/form-input/form-input.component.html
+++ b/projects/ngx-dynamic-form/src/lib/fields/form-input/form-input.component.html
@@ -30,7 +30,7 @@
             />
             <!-- Eye Icon -->
             <span *ngIf="config.fieldType === 'password' && !!group.get(config.name)?.value" style="margin-left: -30px;">
-                <i (click)="togglePassword()" [ngClass]="type === 'password' ? 'fas fa-eye': 'fas fa-eye-slash'"
+                <i (click)="togglePassword()" [ngClass]="type === 'password' ? 'bi bi-eye': 'bi bi-eye-slash'"
                     style="cursor: pointer">
                 </i>
             </span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1620,11 +1620,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz#c57c8afbb4054a3ab8317591a0b7320360b444ae"
   integrity sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==
 
-"@fortawesome/fontawesome-free@^6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.6.0.tgz#0e984f0f2344ee513c185d87d77defac4c0c8224"
-  integrity sha512-60G28ke/sXdtS9KZCpZSHHkCbdsOGEhIUGlwq6yhY74UpTiToIh8np7A8yphhM4BWsvNFtIvLpi4co+h9Mr9Ow==
-
 "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -3127,6 +3122,11 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
+bootstrap-icons@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz#03f9cb754ec005c52f9ee616e2e84a82cab3084b"
+  integrity sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==
 
 bootstrap@^5.3.3:
   version "5.3.3"


### PR DESCRIPTION
# Descripción

Se arreglan los errores que ocurren al implementar la librería en otros proyectos de **Angular 16**.

## Detalles

- Se cambian las dependencias del proyecto, de forma tal que al instalarse la librería se instalen todos los paquetes necesarios para su funcionamiento.
- Se cambia la guía de instalación en los *READMEs* para aumentar la claridad y prevenir errores de uso.
- Se cambia la dependencia `fortawesome` por `bootstrap icons`.