### PR TITLE
[FIX] - Arreglar error ocurrido al no tener la aplicación un enrutamiento

### DIFF
--- a/projects/demo-app/src/app/components/add/add.component.ts
+++ b/projects/demo-app/src/app/components/add/add.component.ts
@@ -30,12 +30,9 @@ import { Validators } from '@angular/forms';
 export class AddComponent extends GenericAddComponent implements AfterViewInit {
   override service: IFieldService;
   constructor(
-    router: Router,
-    activatedRoute: ActivatedRoute,
-    cdr: ChangeDetectorRef,
     private _demoService: DemoService
   ) {
-    super(router, activatedRoute, cdr);
+    super();
     this.service = _demoService;
     this.title = 'Person';
     this.config = [

--- a/projects/ngx-dynamic-form/src/lib/components/generic-add/generic-add.component.ts
+++ b/projects/ngx-dynamic-form/src/lib/components/generic-add/generic-add.component.ts
@@ -1,10 +1,11 @@
-import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, inject, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { takeUntil, finalize, Subscription } from 'rxjs';
 import { DynamicFormComponent } from '../../ngx-dynamic-form.component';
 import { IFieldService } from '../../interfaces/ifield-service';
 import { DestroyComponent } from '../destroy/destroy.component';
 import { IFieldConfig } from '../../interfaces/ifield-config';
+import { messages } from '../../constants/lang.es';
 
 @Component({
   selector: 'generic-add',
@@ -39,13 +40,20 @@ export abstract class GenericAddComponent extends DestroyComponent {
    * Reference to the `DynamicFormComponent` object on the view.
    */
   @ViewChild(DynamicFormComponent) form!: DynamicFormComponent;
+  protected activatedRoute?: ActivatedRoute;
+  protected router?: Router;
+  protected cdr: ChangeDetectorRef;
 
   constructor(
-    protected router: Router,
-    protected activatedRoute: ActivatedRoute,
-    protected cdr: ChangeDetectorRef
   ) {
     super();
+    this.cdr = inject(ChangeDetectorRef)
+    try {
+      this.router = inject(Router)
+      this.activatedRoute = inject(ActivatedRoute)
+    } catch (error) {
+      console.warn(`${messages.NO_ROUTE_PROVIDER}\n${error}`);
+    }
   }
 
   /**
@@ -57,7 +65,7 @@ export abstract class GenericAddComponent extends DestroyComponent {
 
   ngAfterViewInit(): void {
     // get the item if id is defined
-    this.id = this.activatedRoute.snapshot.params['id'];
+    this.id = this.activatedRoute?.snapshot.params['id'];
     !!this.id ? this.getData() : this.form.patchValues({ id: null });
   }
 
@@ -117,6 +125,6 @@ export abstract class GenericAddComponent extends DestroyComponent {
         }),
         takeUntil(this.destroy$)
       )
-      .subscribe(async () => await this.router.navigateByUrl(this.listUrl));
+      .subscribe(async () => await this.router?.navigateByUrl(this.listUrl));
   }
 }

--- a/projects/ngx-dynamic-form/src/lib/constants/lang.es.ts
+++ b/projects/ngx-dynamic-form/src/lib/constants/lang.es.ts
@@ -2,4 +2,5 @@ export const messages = {
     REQUIRED_FIELD: 'Este campo es requerido.',
     UNDEFINED_METHOD_OR_SERVICE: 'El método o el servicio no están definidos.',
     SAVE: 'Guardar',
+    NO_ROUTE_PROVIDER: 'No hay provider para Router. Asegúrese de proveer uno o configurar correctamente las rutas de su proyecto',
 }

--- a/projects/ngx-dynamic-form/src/lib/ngx-dynamic-form.component.ts
+++ b/projects/ngx-dynamic-form/src/lib/ngx-dynamic-form.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  inject,
   Input,
   OnInit,
   Output,
@@ -15,6 +16,7 @@ import { DynamicFieldDirective } from './directives/dynamic-field.directive';
 import { FormButtonComponent } from './components/form-button/form-button.component';
 import { FormHeaderComponent } from './components/form-header/form-header.component';
 import { ActivatedRoute } from '@angular/router';
+import { messages } from './constants/lang.es';
 
 @Component({
   selector: 'ngx-dynamic-form',
@@ -26,7 +28,7 @@ import { ActivatedRoute } from '@angular/router';
     DynamicFieldDirective,
     FormButtonComponent,
     FormHeaderComponent,
-  ],
+  ]
 })
 export class DynamicFormComponent implements OnInit {
   /**
@@ -56,13 +58,21 @@ export class DynamicFormComponent implements OnInit {
   @Input() form!: FormGroup;
   @Output() save: EventEmitter<any> = new EventEmitter<any>();
   isLoading: boolean = false;
+  private _route?: ActivatedRoute;
 
   constructor(
     private _fb: FormBuilder,
     public _formService: FormHelperService,
     private _cdr: ChangeDetectorRef,
-    private _route: ActivatedRoute
-  ) {}
+  ) {
+    try {
+      this._route = inject(ActivatedRoute)
+    } catch (error) {
+      console.warn(
+        `${messages.NO_ROUTE_PROVIDER}\n${error}`
+      );
+    }
+  }
 
   get value() {
     return this.form.value;
@@ -77,7 +87,7 @@ export class DynamicFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    const id = this._route.snapshot.params['id'];
+    const id = this._route?.snapshot.params['id'];
     this.title =
       (!!this.hasPrefix ? (!!id ? 'Editar ' : 'Crear ') : '') + this.title;
     // Build form if is not define.


### PR DESCRIPTION
# Descripción

Cuando una aplicación que no tiene un enrutamiento la librería produce un error `no provider for ActivatedRoute`, lo cual no es correcto pues el `ngx-dynamic-form` debería de funcionar correctamente sin necesidad de un enrutamiento. Para solucionar esto se desacopla un poco la funcionalidad `ActivatedRoute` en los componentes `ngx-dynamic-form` y `generic-add`, siendo necesario todavía pero no obligatorio.

## Detalles

- Modificados componentes `ngx-dynamic-form` y `generic-add` para funcionar sin proveer `ActivatedRoute`.
- Agregada advertencia de necesidad de un enrutamiento para que la librería ejecute todas sus funciones.